### PR TITLE
Add new zabbix_item_external resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,39 @@ Same as arguments, plus:
 
 * preprocessor.#.id - Preprocessor assigned ID number
 
+### zabbix_item_external
+
+```hcl
+resource "zabbix_item_external" "example" {
+  hostid = "1234"
+  key = "script[\"argv1\",\"argv2\"]"
+  name = "Item Name"
+  interfaceid = "5678"
+  valuetype = "unsigned"
+  delay = "1m"
+}
+```
+
+#### Argument Reference
+
+* hostid - (Required) Host/Template ID to attach item to
+* key - (Required) Item Key
+* name - (Required) Item Name
+* interfaceid - (Required) Host interface ID
+* valuetype - (Required) Item valuetype, one of: (float, character, log, unsigned, text)
+* delay - (Optional) Item collection interval, defaults to 1m
+* preprocessor - (Optional) Item Preprocessors
+    * type - (Required) Preprocessor type [docs](https://www.zabbix.com/documentation/current/manual/api/reference/item/object)
+    * params - (Optional) Preprocessor params
+    * error_handler - (Optional) error handler type (see above docs, only relevent in > 4.0)
+    * error_handler_params - (Optional) error handler params (see above docs, only relevent in > 4.0)
+
+#### Attributes Reference
+
+Same as arguments, plus:
+
+* preprocessor.#.id - Preprocessor assigned ID number
+
 ### zabbix_item_internal
 
 ```hcl

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/tpretz/go-zabbix-api v0.4.4 h1:Vsorm0i6/blIlohRw8wMV5X+Ucgmt0f2w0jDOJ
 github.com/tpretz/go-zabbix-api v0.4.4/go.mod h1:SFemU2FNM7aeT3/NinjDw0SQEZGVOoU5d+CqXKTetbw=
 github.com/tpretz/go-zabbix-api v0.4.6 h1:3f1tzS3wG7B3ZciAp8jB2g0/EXEHPY4OQ5PfOLUni3g=
 github.com/tpretz/go-zabbix-api v0.4.6/go.mod h1:SFemU2FNM7aeT3/NinjDw0SQEZGVOoU5d+CqXKTetbw=
+github.com/tpretz/go-zabbix-api v0.4.7 h1:IPdx4JNp2dcyqf3C6S99o8uqZ2X1Qz87lprl4wwBwd4=
+github.com/tpretz/go-zabbix-api v0.4.7/go.mod h1:SFemU2FNM7aeT3/NinjDw0SQEZGVOoU5d+CqXKTetbw=
 github.com/ugorji/go v0.0.0-20180813092308-00b869d2f4a5/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -56,6 +56,7 @@ func Provider() *schema.Provider {
 			"zabbix_item_trapper":   resourceItemTrapper(),
 			"zabbix_item_http":      resourceItemHttp(),
 			"zabbix_item_simple":    resourceItemSimple(),
+			"zabbix_item_external":  resourceItemExternal(),
 			"zabbix_item_internal":  resourceItemInternal(),
 			"zabbix_item_snmp":      resourceItemSnmp(),
 			"zabbix_item_agent":     resourceItemAgent(),

--- a/provider/resource_itemexternal.go
+++ b/provider/resource_itemexternal.go
@@ -23,8 +23,8 @@ func resourceItemExternal() *schema.Resource {
 // Custom mod handler for item type
 func itemExternalModFunc(d *schema.ResourceData, item *zabbix.Item) {
 	item.Type = zabbix.ExternalCheck
-	item.Delay = d.Get("delay").(string)
 	item.InterfaceID = d.Get("interfaceid").(string)
+	item.Delay = d.Get("delay").(string)
 }
 
 // Custom read handler for item type

--- a/provider/resource_itemexternal.go
+++ b/provider/resource_itemexternal.go
@@ -1,0 +1,34 @@
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/tpretz/go-zabbix-api"
+)
+
+// terraform resource handler for item type
+func resourceItemExternal() *schema.Resource {
+	return &schema.Resource{
+		Create: itemGetCreateWrapper(itemExternalModFunc, itemExternalReadFunc),
+		Read:   itemGetReadWrapper(itemExternalReadFunc),
+		Update: itemGetUpdateWrapper(itemExternalModFunc, itemExternalReadFunc),
+		Delete: resourceItemDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: mergeSchemas(itemCommonSchema, itemDelaySchema, itemInterfaceSchema),
+	}
+}
+
+// Custom mod handler for item type
+func itemExternalModFunc(d *schema.ResourceData, item *zabbix.Item) {
+	item.Type = zabbix.ExternalCheck
+	item.Delay = d.Get("delay").(string)
+	item.InterfaceID = d.Get("interfaceid").(string)
+}
+
+// Custom read handler for item type
+func itemExternalReadFunc(d *schema.ResourceData, item *zabbix.Item) {
+	d.Set("interfaceid", item.InterfaceID)
+	d.Set("delay", item.Delay)
+}

--- a/provider/resource_itemsimple.go
+++ b/provider/resource_itemsimple.go
@@ -16,7 +16,7 @@ func resourceItemSimple() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema: mergeSchemas(itemCommonSchema, itemDelaySchema),
+		Schema: mergeSchemas(itemCommonSchema, itemDelaySchema, itemInterfaceSchema),
 	}
 }
 
@@ -24,9 +24,11 @@ func resourceItemSimple() *schema.Resource {
 func itemSimpleModFunc(d *schema.ResourceData, item *zabbix.Item) {
 	item.Delay = d.Get("delay").(string)
 	item.Type = zabbix.SimpleCheck
+	item.InterfaceID = d.Get("interfaceid").(string)
 }
 
 // Custom read handler for item type
 func itemSimpleReadFunc(d *schema.ResourceData, item *zabbix.Item) {
+	d.Set("interfaceid", item.InterfaceID)
 	d.Set("delay", item.Delay)
 }


### PR DESCRIPTION
This PR adds the new Terraform resource `zabbix_item_external`, along with required arguments.

I've also updated `zabbix_item_simple` to require that `interfaceid` is provided, following the API docs. It when it wasn't supplied I was seeing this error:

```none
zabbix_item_simple.example: Creating...

Error: -32602 (Invalid params.): No interface found.

  on zabbix.tf line 26, in resource "zabbix_item_simple" "example":
  26: resource "zabbix_item_simple" "example" {
```
