### PR TITLE
extends LLD macro to allow underscore

### DIFF
--- a/provider/common_lld.go
+++ b/provider/common_lld.go
@@ -151,7 +151,7 @@ var lldPreprocessorSchema = &schema.Schema{
 	},
 }
 
-var lldValidationMacro = validation.StringMatch(regexp.MustCompile("^\\{#[A-Z][A-Z.]*\\}$"), "must be a LLD macro format")
+var lldValidationMacro = validation.StringMatch(regexp.MustCompile("^\\{#[A-Z][A-Z._]*\\}$"), "must be a LLD macro format")
 
 var lldMacroPathSchema = &schema.Schema{
 	Type:     schema.TypeSet,


### PR DESCRIPTION
Hello,

As I have been using this provider from few days , It's nice and I really like it..!

I have added underscore to regexp at lldValidationMacro to support _LLD Filter_ "label macro".
Above changes accept "label macro" name with underscore, for example:-  {#MACRO_NAME}  

Best regards