### PR TITLE
fix(proxy): error if no proxy was found

### DIFF
--- a/provider/resource_proxy.go
+++ b/provider/resource_proxy.go
@@ -61,13 +61,14 @@ func proxyRead(d *schema.ResourceData, m interface{}, params zabbix.Params) erro
 		return err
 	}
 
-	if len(proxys) < 1 {
-		d.SetId("")
-		return nil
+	if len(proxys) == 0 {
+		return fmt.Errorf("cannot find proxy") 
 	}
+	
 	if len(proxys) > 1 {
 		return errors.New("multiple proxys found")
 	}
+	
 	proxy := proxys[0]
 
 	log.Debug("Got proxy: %+v", proxy)


### PR DESCRIPTION
Introduced the change to return an error in case no proxy was found for the `zabbix_proxy` data source for a specified host. 

Otherwise the id is `0` which is not helpful for further terraform resources